### PR TITLE
fix: replace break with return in termination case

### DIFF
--- a/verkle-tests/main_test.go
+++ b/verkle-tests/main_test.go
@@ -375,7 +375,7 @@ func printNodeInfoUntilStopped(
 			case <-time.Tick(6 * time.Second):
 				printAllNodesInfo(ctx, nodeClientsByServiceIds)
 			case <-printingStopChan:
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
The node status printing routine is `select`-ing on a channel for its termination signal. It is using `break` in order  to exit the infinite loop, but without a label, the `break` corresponds to the `select` statement, and not the `for` statement.

Uses `return` instead to ensure that the goroutine terminates.